### PR TITLE
fix: resolve issue with custom interests getting clobbered

### DIFF
--- a/apps/api/lib/flirtual/profiles.ex
+++ b/apps/api/lib/flirtual/profiles.ex
@@ -126,7 +126,7 @@ defmodule Flirtual.Profiles do
       |> validate_length(:platform, min: 1, max: 8)
       |> validate_attributes(:interest_id, "interest")
       |> then(fn changeset ->
-        if not changed?(changeset, :interest_id) or not changed?(changeset, :custom_interests) do
+        if not changed?(changeset, :interest_id) and not changed?(changeset, :custom_interests) do
           changeset
         else
           interests =


### PR DESCRIPTION
this condition was wrong, causing changes to interests to sometimes get discarded.

please test thoroughly to make sure this change doesn't break something else.  if it does then we will probably need to change the frontend and revert this change.

resolves #98