### PR TITLE
fix: make last message relative time accurate to minutes, not seconds

### DIFF
--- a/apps/frontend/src/app/(authenticated)/(email-confirmed)/matches/list-item.tsx
+++ b/apps/frontend/src/app/(authenticated)/(email-confirmed)/matches/list-item.tsx
@@ -86,7 +86,7 @@ export const ConversationListItem: FC<ConversationListItemProps> = (props) => {
 						</span>
 						{lastMessage && (
 							<TimeRelative
-								approximate={true}
+								approximate
 								approximateTo={60}
 								value={lastMessage.createdAt}
 								elementProps={{

--- a/apps/frontend/src/app/(authenticated)/(email-confirmed)/matches/list-item.tsx
+++ b/apps/frontend/src/app/(authenticated)/(email-confirmed)/matches/list-item.tsx
@@ -86,6 +86,8 @@ export const ConversationListItem: FC<ConversationListItemProps> = (props) => {
 						</span>
 						{lastMessage && (
 							<TimeRelative
+								approximate={true}
+								approximateTo={60}
 								value={lastMessage.createdAt}
 								elementProps={{
 									className: "shrink-0 text-xs text-black-60 dark:text-white-50"

--- a/apps/frontend/src/date.ts
+++ b/apps/frontend/src/date.ts
@@ -11,6 +11,7 @@ export function yearsAgo(date: Date): number {
 
 export interface RelativeTimeOptions {
 	approximate?: boolean;
+	approximateTo?: number;
 	suffix?: string;
 }
 
@@ -18,10 +19,11 @@ export function relativeTime(
 	date: Date,
 	options: RelativeTimeOptions = {}
 ): string {
-	const { approximate = true, suffix = "ago" } = options;
+	const { approximate = true, approximateTo = 5, suffix = "ago" } = options;
 	const since = Date.now() - date.getTime();
 
-	if (approximate && since < secondInMilliseconds * 5) return "just now";
+	if (approximate && since < secondInMilliseconds * approximateTo)
+		return "just now";
 
 	if (since < minuteInMilliseconds) {
 		const seconds = Math.floor(since / secondInMilliseconds);


### PR DESCRIPTION
I added an extra prop to the `relativeTime` component.  originally tried setting the `every` prop on `TimeRelative` but it was weird and didn't seem to work quite correctly.  this gives the exact desired behavior from the issue.

resolves #86 