### PR TITLE
fix: Kink attributes and languages now highlight correctly

### DIFF
--- a/apps/frontend/src/components/profile/pill/attribute-list.tsx
+++ b/apps/frontend/src/components/profile/pill/attribute-list.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from "react";
 
-import { Attribute } from "~/api/attributes";
+import { Attribute, AttributeMetadata } from "~/api/attributes";
 import { User } from "~/api/user";
 import { useSession } from "~/hooks/use-session";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
@@ -28,9 +28,22 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 		session.user.profile.attributes.map(({ id }) => id)
 	);
 
+	const attributeMatches = (
+		id: string,
+		type: string,
+		metadata: unknown
+	): boolean => {
+		let targetId = id;
+		if (type === "kink") {
+			const kinkMetadata = metadata as AttributeMetadata["kink"];
+			if (kinkMetadata.pair) targetId = kinkMetadata.pair;
+		}
+		return sessionAttributeIds.has(targetId);
+	};
+
 	return (
 		<div className="flex w-full flex-wrap gap-2">
-			{attributes.map(({ id, name, metadata }) => {
+			{attributes.map(({ id, type, name, metadata }) => {
 				const meta = metadata as {
 					definition?: string;
 					definitionLink?: string;
@@ -43,7 +56,8 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 								<Pill
 									href={href}
 									active={
-										session.user.id !== user.id && sessionAttributeIds.has(id)
+										session.user.id !== user.id &&
+										attributeMatches(id, type, metadata)
 									}
 								>
 									{name}

--- a/apps/frontend/src/components/profile/pill/attribute-list.tsx
+++ b/apps/frontend/src/components/profile/pill/attribute-list.tsx
@@ -14,7 +14,7 @@ interface PillAttributeListProps {
 	attributes?: Array<Attribute>;
 	user: User;
 	href?: string;
-	activeIds?: Set<string>;
+	activeIds?: Array<string>;
 }
 
 export const PillAttributeList: FC<PillAttributeListProps> = ({
@@ -26,7 +26,7 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 	const [session] = useSession();
 	if (!session || !attributes?.length) return null;
 	const attributeIds =
-		activeIds || new Set(session.user.profile.attributes.map(({ id }) => id));
+		activeIds || session.user.profile.attributes.map(({ id }) => id);
 
 	return (
 		<div className="flex w-full flex-wrap gap-2">
@@ -41,7 +41,7 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 						<TooltipTrigger asChild>
 							<div>
 								<Pill
-									active={session.user.id !== user.id && attributeIds.has(id)}
+									active={session.user.id !== user.id && attributeIds.includes(id)}
 									href={href}
 								>
 									{name}

--- a/apps/frontend/src/components/profile/pill/attribute-list.tsx
+++ b/apps/frontend/src/components/profile/pill/attribute-list.tsx
@@ -37,6 +37,8 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 		if (type === "kink") {
 			const kinkMetadata = metadata as AttributeMetadata["kink"];
 			if (kinkMetadata.pair) targetId = kinkMetadata.pair;
+		} else if (type === "language") {
+			return session.user.profile.languages.includes(targetId);
 		}
 		return sessionAttributeIds.has(targetId);
 	};

--- a/apps/frontend/src/components/profile/pill/attribute-list.tsx
+++ b/apps/frontend/src/components/profile/pill/attribute-list.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from "react";
 
-import { Attribute, AttributeMetadata } from "~/api/attributes";
+import { Attribute } from "~/api/attributes";
 import { User } from "~/api/user";
 import { useSession } from "~/hooks/use-session";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
@@ -14,38 +14,23 @@ interface PillAttributeListProps {
 	attributes?: Array<Attribute>;
 	user: User;
 	href?: string;
+	activeIds?: Set<string>;
 }
 
 export const PillAttributeList: FC<PillAttributeListProps> = ({
 	user,
 	attributes,
-	href
+	href,
+	activeIds
 }) => {
 	const [session] = useSession();
 	if (!session || !attributes?.length) return null;
-
-	const sessionAttributeIds = new Set(
-		session.user.profile.attributes.map(({ id }) => id)
-	);
-
-	const attributeMatches = (
-		id: string,
-		type: string,
-		metadata: unknown
-	): boolean => {
-		let targetId = id;
-		if (type === "kink") {
-			const kinkMetadata = metadata as AttributeMetadata["kink"];
-			if (kinkMetadata.pair) targetId = kinkMetadata.pair;
-		} else if (type === "language") {
-			return session.user.profile.languages.includes(targetId);
-		}
-		return sessionAttributeIds.has(targetId);
-	};
+	const attributeIds =
+		activeIds || new Set(session.user.profile.attributes.map(({ id }) => id));
 
 	return (
 		<div className="flex w-full flex-wrap gap-2">
-			{attributes.map(({ id, type, name, metadata }) => {
+			{attributes.map(({ id, name, metadata }) => {
 				const meta = metadata as {
 					definition?: string;
 					definitionLink?: string;
@@ -56,11 +41,8 @@ export const PillAttributeList: FC<PillAttributeListProps> = ({
 						<TooltipTrigger asChild>
 							<div>
 								<Pill
+									active={session.user.id !== user.id && attributeIds.has(id)}
 									href={href}
-									active={
-										session.user.id !== user.id &&
-										attributeMatches(id, type, metadata)
-									}
 								>
 									{name}
 								</Pill>

--- a/apps/frontend/src/components/profile/pill/expansion.tsx
+++ b/apps/frontend/src/components/profile/pill/expansion.tsx
@@ -7,7 +7,8 @@ import { User } from "~/api/user";
 import { Session } from "~/api/auth";
 import { ProfileMonopolyLabel } from "~/api/user/profile";
 import { urls } from "~/urls";
-import { Attribute } from "~/api/attributes";
+import { Attribute, AttributeMetadata } from "~/api/attributes";
+import { filterBy } from "~/utilities";
 
 import { PillAttributeList } from "./attribute-list";
 import { Pill } from "./pill";
@@ -44,8 +45,17 @@ export const PillCollectionExpansion: FC<PillCollectionExpansionProps> = (
 				attributes={attributes.kink}
 				href={editable ? urls.settings.nsfw : undefined}
 				user={user}
+				activeIds={
+					new Set(
+						filterBy(session.user.profile.attributes, "type", "kink").map(
+							(attribute) =>
+								(attribute.metadata as AttributeMetadata["kink"]).pair
+						)
+					)
+				}
 			/>
 			<PillAttributeList
+				activeIds={new Set(session.user.profile.languages)}
 				attributes={attributes.language}
 				href={editable ? urls.settings.tags("language") : undefined}
 				user={user}

--- a/apps/frontend/src/components/profile/pill/expansion.tsx
+++ b/apps/frontend/src/components/profile/pill/expansion.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { FC, useState } from "react";
+import { FC, useMemo, useState } from "react";
 import { EllipsisHorizontalIcon } from "@heroicons/react/24/solid";
 
 import { User } from "~/api/user";
 import { Session } from "~/api/auth";
 import { ProfileMonopolyLabel } from "~/api/user/profile";
 import { urls } from "~/urls";
-import { Attribute, AttributeMetadata } from "~/api/attributes";
+import { Attribute } from "~/api/attributes";
 import { filterBy } from "~/utilities";
+import { useAttributeList } from "~/hooks/use-attribute-list";
 
 import { PillAttributeList } from "./attribute-list";
 import { Pill } from "./pill";
@@ -26,6 +27,15 @@ export const PillCollectionExpansion: FC<PillCollectionExpansionProps> = (
 	const { editable, user, attributes, session } = props;
 	const [expanded, setExpanded] = useState(false);
 
+	const kinks = useAttributeList("kink");
+	const activeKinkIds = useMemo(
+		() =>
+			filterBy(session.user.profile.attributes, "type", "kink")
+				.map(({ id }) => kinks.find((kink) => kink.id === id)?.metadata.pair)
+				.filter(Boolean),
+		[kinks, session.user.profile.attributes]
+	);
+
 	return expanded ? (
 		<>
 			{user.profile.monopoly && (
@@ -42,20 +52,13 @@ export const PillCollectionExpansion: FC<PillCollectionExpansionProps> = (
 				</div>
 			)}
 			<PillAttributeList
+				activeIds={activeKinkIds}
 				attributes={attributes.kink}
 				href={editable ? urls.settings.nsfw : undefined}
 				user={user}
-				activeIds={
-					new Set(
-						filterBy(session.user.profile.attributes, "type", "kink").map(
-							(attribute) =>
-								(attribute.metadata as AttributeMetadata["kink"]).pair
-						)
-					)
-				}
 			/>
 			<PillAttributeList
-				activeIds={new Set(session.user.profile.languages)}
+				activeIds={session.user.profile.languages}
 				attributes={attributes.language}
 				href={editable ? urls.settings.tags("language") : undefined}
 				user={user}


### PR DESCRIPTION
Another improvement to tag highlighting, this time focusing on NSFW kink-related tags.  Before you would see tags highlighted if you had both selected the same kink, but what people really want to know is when a giving/receiving kink matches up - e.g. Brat and Brat Tamer, or Rope Bunny and Rigger.

We had this in the data already via the metadata property, we just weren't using it.  This PR adjusts the `AttributeList` component to use the pair metadata value when the attribute type being checked is `kink`.

EDIT: Also decided to fix #105.